### PR TITLE
Use fixed counter address in snapshots

### DIFF
--- a/.changeset/soft-elephants-compete.md
+++ b/.changeset/soft-elephants-compete.md
@@ -1,0 +1,7 @@
+---
+"create-solana-program": patch
+---
+
+Use fixed counter address in snapshots
+
+This prevents new keypairs from being generated and avoids having lots of unnecessary address changes between snapshots.

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,6 +1,7 @@
+export const COUNTER_ADDRESS = 'CounterProgram111111111111111111111111111111';
 export const CLIENTS = ['js', 'rust'];
 export const PROJECTS = {
-  'counter-shank': ['counter', '--shank'],
+  'counter-shank': ['counter', '--shank', '--address', COUNTER_ADDRESS],
 };
 
 export async function executeStep(title, fn) {


### PR DESCRIPTION
This prevents new key pairs from being generated and avoids having lots of unnecessary address changes between snapshots.