### PR TITLE
Not start validator for Rust client tests

### DIFF
--- a/.changeset/tricky-rules-give.md
+++ b/.changeset/tricky-rules-give.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Not start validator for Rust client tests

--- a/template/clients/rust/scripts/client/test-rust.mjs
+++ b/template/clients/rust/scripts/client/test-rust.mjs
@@ -2,9 +2,6 @@
 import 'zx/globals';
 import { workingDirectory } from '../utils.mjs';
 
-// Start the local validator if it's not already running.
-await $`pnpm validator:restart`;
-
 // Run the tests.
 cd(path.join(workingDirectory, 'clients', 'rust'));
 const hasSolfmt = await which('solfmt', { nothrow: true });


### PR DESCRIPTION
Rust client tests do not need the validator to run.