### PR TITLE
Add fallback logic for sha checksum

### DIFF
--- a/.changeset/neat-pumpkins-suffer.md
+++ b/.changeset/neat-pumpkins-suffer.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Add fallback logic for sha checksum


### PR DESCRIPTION
Not all systems have `sha256sum` by default (e.g., macOS), so this PR adds a fallback option to look for `shasum`. Additionally, it does not fail even if no checksum program is found and prints a warning instead.