### PR TITLE
Point to correct location for TypeScript definitions

### DIFF
--- a/.changeset/neat-brooms-crash.md
+++ b/.changeset/neat-brooms-crash.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Point to correct location for TypeScript definitions

--- a/template/clients/js/clients/js/package.json.njk
+++ b/template/clients/js/clients/js/package.json.njk
@@ -3,12 +3,12 @@
   "version": "0.0.0",
   "description": "JavaScript client for the {{ programName | titleCase }} program",
   "sideEffects": false,
-  "module": "dist/src/index.mjs",
-  "main": "dist/src/index.js",
-  "types": "dist/types/index.d.ts",
+  "module": "./dist/src/index.mjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/src/index.mjs",
       "require": "./dist/src/index.js"
     }


### PR DESCRIPTION
1. `pnpm add @solana-program/system`
2. Import it into a program

Observe that the import has no type information.

<img width="957" alt="image" src="https://github.com/solana-program/create-solana-program/assets/13243/e484f4ef-5620-48ff-90b4-3bcc0c84496a">
