### PR TITLE
Mark the generated client as an ES Module

### DIFF
--- a/.changeset/silent-paws-repeat.md
+++ b/.changeset/silent-paws-repeat.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Generated clients can now be imported into ESM projects

--- a/template/clients/js/clients/js/package.json.njk
+++ b/template/clients/js/clients/js/package.json.njk
@@ -6,6 +6,7 @@
   "module": "./dist/src/index.mjs",
   "main": "./dist/src/index.js",
   "types": "./dist/types/src/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/types/src/index.d.ts",

--- a/template/clients/js/clients/js/test/_setup.ts
+++ b/template/clients/js/clients/js/test/_setup.ts
@@ -23,7 +23,7 @@ import {
   setTransactionLifetimeUsingBlockhash,
   signTransactionWithSigners,
 } from '@solana/web3.js';
-import { findCounterPda, getCreateInstructionAsync } from '../src';
+import { findCounterPda, getCreateInstructionAsync } from '../src/index.js';
 
 type Client = {
   rpc: Rpc<SolanaRpcApi>;

--- a/template/clients/js/clients/js/test/create.test.ts
+++ b/template/clients/js/clients/js/test/create.test.ts
@@ -4,13 +4,13 @@ import {
   Counter,
   fetchCounterFromSeeds,
   getCreateInstructionAsync,
-} from '../src';
+} from '../src/index.js';
 import {
   createDefaultSolanaClient,
   createDefaultTransaction,
   generateKeyPairSignerWithSol,
   signAndSendTransaction,
-} from './_setup';
+} from './_setup.js';
 
 test('it creates a new counter account', async (t) => {
   // Given an authority key pair with some SOL.

--- a/template/clients/js/clients/js/test/increment.test.ts.njk
+++ b/template/clients/js/clients/js/test/increment.test.ts.njk
@@ -5,7 +5,7 @@ import {
   findCounterPda,
   getIncrementInstruction,
   getIncrementInstructionAsync,
-} from '../src';
+} from '../src/index.js';
 import {
   createCounterForAuthority,
   createDefaultSolanaClient,
@@ -13,7 +13,7 @@ import {
   generateKeyPairSignerWithSol,
   getBalance,
   signAndSendTransaction,
-} from './_setup';
+} from './_setup.js';
 
 test('it increments an existing counter by 1 by default', async (t) => {
   // Given an authority key pair with an associated counter account of value 0.

--- a/template/clients/js/clients/js/tsconfig.json
+++ b/template/clients/js/clients/js/tsconfig.json
@@ -8,7 +8,7 @@
       "forceConsistentCasingInFileNames": true,
       "inlineSources": false,
       "isolatedModules": true,
-      "module": "commonjs",
+      "module": "ESNext",
       "moduleResolution": "node",
       "noFallthroughCasesInSwitch": true,
       "noUnusedLocals": true,

--- a/template/clients/js/clients/js/tsup.config.ts
+++ b/template/clients/js/clients/js/tsup.config.ts
@@ -21,7 +21,7 @@ export default defineConfig(() => [
     ...SHARED_OPTIONS,
     bundle: false,
     entry: ['./test/*.ts'],
-    format: 'cjs',
+    format: 'esm',
     outDir: './dist/test',
   },
 ]);


### PR DESCRIPTION
Without this, you essentially can't import generated clients into a project that, itself, is an ESModule.