### PR TITLE
Fix exported extensions in package.json

### DIFF
--- a/.changeset/giant-taxis-sneeze.md
+++ b/.changeset/giant-taxis-sneeze.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Fix exported extensions in package.json

--- a/template/clients/js/clients/js/package.json.njk
+++ b/template/clients/js/clients/js/package.json.njk
@@ -3,15 +3,15 @@
   "version": "0.0.0",
   "description": "JavaScript client for the {{ programName | titleCase }} program",
   "sideEffects": false,
-  "module": "./dist/src/index.mjs",
-  "main": "./dist/src/index.js",
+  "module": "./dist/src/index.js",
+  "main": "./dist/src/index.cjs",
   "types": "./dist/types/src/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
       "types": "./dist/types/src/index.d.ts",
-      "import": "./dist/src/index.mjs",
-      "require": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "require": "./dist/src/index.cjs"
     }
   },
   "files": [

--- a/template/clients/js/clients/js/tsup.config.ts
+++ b/template/clients/js/clients/js/tsup.config.ts
@@ -7,6 +7,7 @@ const SHARED_OPTIONS: Options = {
   entry: ['./src/index.ts'],
   inject: [path.resolve(__dirname, 'env-shim.ts')],
   outDir: './dist/src',
+  outExtension: ({ format }) => ({ js: format === 'cjs' ? '.cjs' : '.js' }),
   sourcemap: true,
   treeshake: true,
 };


### PR DESCRIPTION
Before adding the “module” package type in #21, `tsup` was generating CJS files as `.js` and ESM files as `.mjs`. After the PR, `tsup` started doing the opposite — i.e. CJS files as `.cjs` and ESM files as `.js` meaning our `package.json` was pointing to the wrong files.

This PR fixes this by updating the `package.json` accordingly but also defining the extension logic explicitly so we don’t get this sort of surprise in the future.

## Test plan

I've updated `@solana-program/system`, `@solana-program/memo`, `@solana-program/address-lookup-table` and `@solana-program/compute-budget` with this patch. Before, they didn't work on CodeSandbox, now they do.