### PR TITLE
improve Rust close-account fn performance

### DIFF
--- a/.changeset/fifty-experts-hunt.md
+++ b/.changeset/fifty-experts-hunt.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Improve close account helper function performance in Rust client

--- a/template/programs/counter-shank/program/src/utils.rs
+++ b/template/programs/counter-shank/program/src/utils.rs
@@ -5,7 +5,7 @@ use solana_program::{
     program_error::ProgramError,
     pubkey::Pubkey,
     rent::Rent,
-    system_instruction,
+    system_instruction, system_program,
     sysvar::Sysvar,
 };
 

--- a/template/programs/counter-shank/program/src/utils.rs
+++ b/template/programs/counter-shank/program/src/utils.rs
@@ -83,10 +83,8 @@ pub fn close_account<'a>(
         .unwrap();
     **target_account.lamports.borrow_mut() = 0;
 
-    let mut src_data = target_account.data.borrow_mut();
-    src_data.fill(0);
-
-    Ok(())
+    target_account.assign(&system_program::ID);
+    target_account.realloc(0, false)
 }
 
 /// Transfer lamports.


### PR DESCRIPTION
This adds a minor performance improvement to the `close_account` function in the Shank example Counter Program utils file. Instead of filling the account with zeros, a more efficient way to close accounts is to reassign to the system program and then realloc the length to zero. This is how [Anchor does it](https://github.com/coral-xyz/anchor/blob/e71a63cb7ae2eaefc4c2f31d04af140434ee0049/lang/src/common.rs#L13), for example.