### PR TITLE
Suppress node warnings

### DIFF
--- a/template/clients/js/clients/js/package.json.njk
+++ b/template/clients/js/clients/js/package.json.njk
@@ -53,6 +53,7 @@
     "typescript": "^5.4.2"
   },
   "ava": {
+    "nodeArguments": ["--no-warnings"],
     "require": [
       "@solana/webcrypto-ed25519-polyfill"
     ],


### PR DESCRIPTION
This PR suppress node warnings to hide polyfill messages when running ava.