### PR TITLE
Add support for external accounts

### DIFF
--- a/.changeset/orange-rats-agree.md
+++ b/.changeset/orange-rats-agree.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Add support for external accounts

--- a/template/anchor/base/program/Cargo.toml.njk
+++ b/template/anchor/base/program/Cargo.toml.njk
@@ -9,6 +9,7 @@ publish = false
 [package.metadata.solana]
 program-id = "{{ programAddress }}"
 program-dependencies = []
+account-dependencies = []
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/template/base/scripts/program/dump.mjs
+++ b/template/base/scripts/program/dump.mjs
@@ -29,7 +29,7 @@ async function dump() {
 
   // Copy the binaries from the chain or warn if they are different.
   await Promise.all(
-    external.map(async (address, extension) => {
+    external.map(async ([address, extension]) => {
       const binary = `${address}.${extension}`;
       const hasBinary = await fs.exists(`${outputDir}/${binary}`);
 

--- a/template/base/scripts/program/dump.mjs
+++ b/template/base/scripts/program/dump.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env zx
 import 'zx/globals';
 import {
+  getExternalAccountAddresses,
   getExternalProgramAddresses,
   getExternalProgramOutputDir,
 } from '../utils.mjs';

--- a/template/base/scripts/utils.mjs
+++ b/template/base/scripts/utils.mjs
@@ -29,7 +29,7 @@ export function getExternalProgramAddresses() {
 export function getExternalAccountAddresses() {
   const addresses = getProgramFolders().flatMap(
     (folder) =>
-      getCargo(folder).package?.metadata?.solana?.["account-dependencies"] ?? []
+      getCargo(folder).package?.metadata?.solana?.['account-dependencies'] ?? []
   );
   return Array.from(new Set(addresses));
 }

--- a/template/base/scripts/utils.mjs
+++ b/template/base/scripts/utils.mjs
@@ -26,6 +26,14 @@ export function getExternalProgramAddresses() {
   return Array.from(new Set(addresses));
 }
 
+export function getExternalAccountAddresses() {
+  const addresses = getProgramFolders().flatMap(
+    (folder) =>
+      getCargo(folder).package?.metadata?.solana?.["account-dependencies"] ?? []
+  );
+  return Array.from(new Set(addresses));
+}
+
 let didWarnAboutMissingPrograms = false;
 export function getProgramFolders() {
   let programs;

--- a/template/clients/base/scripts/start-validator.mjs
+++ b/template/clients/base/scripts/start-validator.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import 'zx/globals';
 import {
   getCargo,
+  getExternalAccountAddresses,
   getExternalProgramAddresses,
   getExternalProgramOutputDir,
   getProgramFolders,
@@ -21,10 +22,18 @@ if (!restart && isValidatorRunning) {
 
 // Initial message.
 const verb = isValidatorRunning ? 'Restarting' : 'Starting';
+
+// Get programs and accounts.
 const programs = [...getPrograms(), ...getExternalPrograms()];
 const programPluralized = programs.length === 1 ? 'program' : 'programs';
+const accounts = [...getExternalAccounts()];
+const accountsPluralized = accounts.length === 1 ? 'account' : 'accounts';
+
 echo(
-  `${verb} local validator with ${programs.length} custom ${programPluralized}...`
+  `${verb} local validator with ${programs.length} custom ${programPluralized}` +
+    (accounts.length > 0
+      ? ` and ${accounts.length} external ${accountsPluralized}...`
+      : `...`)
 );
 
 // Kill the validator if it's already running.
@@ -39,6 +48,11 @@ const args = [/* Reset ledger */ '-r'];
 // Load programs.
 programs.forEach(({ programId, deployPath }) => {
   args.push(/* Load BPF program */ '--bpf-program', programId, deployPath);
+});
+
+// Load accounts.
+accounts.forEach(({ account, deployPath }) => {
+  args.push(/* Load account */ '--account', account, deployPath);
 });
 
 // Start the validator in detached mode.
@@ -96,5 +110,13 @@ function getExternalPrograms() {
   return getExternalProgramAddresses().map((address) => ({
     programId: address,
     deployPath: path.join(binaryDir, `${address}.so`),
+  }));
+}
+
+function getExternalAccounts() {
+  const binaryDir = getExternalProgramOutputDir();
+  return getExternalAccountAddresses().map((address) => ({
+    account: address,
+    deployPath: path.join(binaryDir, `${address}.json`),
   }));
 }

--- a/template/shank/base/program/Cargo.toml.njk
+++ b/template/shank/base/program/Cargo.toml.njk
@@ -9,6 +9,7 @@ publish = false
 [package.metadata.solana]
 program-id = "{{ programAddress }}"
 program-dependencies = []
+account-dependencies = []
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
This PR adds support for loading external accounts as dependencies. These are specified on `Cargo.toml` as a list of addresses under a `account-dependencies` property – e.g.,:

```rust
[package.metadata.solana]
program-id = "11111111111111111111111111111111"
account-dependencies = ["SysvarC1ock11111111111111111111111111111111"]
```