### PR TITLE
Use `cd` function on scripts

### DIFF
--- a/.changeset/hungry-forks-worry.md
+++ b/.changeset/hungry-forks-worry.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Switch to use cd function

--- a/.changeset/nasty-timers-lay.md
+++ b/.changeset/nasty-timers-lay.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Fix command-line args parsing on scripts

--- a/template/base/scripts/program/build.mjs
+++ b/template/base/scripts/program/build.mjs
@@ -9,6 +9,6 @@ import './dump.mjs';
 await Promise.all(
   getProgramFolders().map(async (folder) => {
     await $`cd ${path.join(workingDirectory, folder)}`.quiet();
-    await $`cargo-build-sbf ${argv._}`;
+    await $`cargo-build-sbf ${process.argv.slice(3)}`;
   })
 );

--- a/template/base/scripts/program/build.mjs
+++ b/template/base/scripts/program/build.mjs
@@ -8,7 +8,7 @@ import './dump.mjs';
 // Build the programs.
 await Promise.all(
   getProgramFolders().map(async (folder) => {
-    await $`cd ${path.join(workingDirectory, folder)}`.quiet();
+    cd(`${path.join(workingDirectory, folder)}`);
     await $`cargo-build-sbf ${process.argv.slice(3)}`;
   })
 );

--- a/template/base/scripts/program/format.mjs
+++ b/template/base/scripts/program/format.mjs
@@ -5,7 +5,7 @@ import { workingDirectory, getProgramFolders } from '../utils.mjs';
 // Format the programs.
 await Promise.all(
   getProgramFolders().map(async (folder) => {
-    await $`cd ${path.join(workingDirectory, folder)}`.quiet();
+    cd(`${path.join(workingDirectory, folder)}`);
     await $`cargo fmt ${process.argv.slice(3)}`;
   })
 );

--- a/template/base/scripts/program/format.mjs
+++ b/template/base/scripts/program/format.mjs
@@ -6,6 +6,6 @@ import { workingDirectory, getProgramFolders } from '../utils.mjs';
 await Promise.all(
   getProgramFolders().map(async (folder) => {
     await $`cd ${path.join(workingDirectory, folder)}`.quiet();
-    await $`cargo fmt ${argv._}`;
+    await $`cargo fmt ${process.argv.slice(3)}`;
   })
 );

--- a/template/base/scripts/program/lint.mjs
+++ b/template/base/scripts/program/lint.mjs
@@ -6,6 +6,6 @@ import { workingDirectory, getProgramFolders } from '../utils.mjs';
 await Promise.all(
   getProgramFolders().map(async (folder) => {
     await $`cd ${path.join(workingDirectory, folder)}`.quiet();
-    await $`cargo clippy ${argv._}`;
+    await $`cargo clippy ${process.argv.slice(3)}`;
   })
 );

--- a/template/base/scripts/program/lint.mjs
+++ b/template/base/scripts/program/lint.mjs
@@ -5,7 +5,7 @@ import { workingDirectory, getProgramFolders } from '../utils.mjs';
 // Lint the programs using clippy.
 await Promise.all(
   getProgramFolders().map(async (folder) => {
-    await $`cd ${path.join(workingDirectory, folder)}`.quiet();
+    cd(`${path.join(workingDirectory, folder)}`);
     await $`cargo clippy ${process.argv.slice(3)}`;
   })
 );

--- a/template/base/scripts/program/test.mjs
+++ b/template/base/scripts/program/test.mjs
@@ -12,9 +12,9 @@ await Promise.all(
     const hasSolfmt = await which('solfmt', { nothrow: true });
 
     if (hasSolfmt) {
-      await $`RUST_LOG=error cargo test-sbf ${argv._} 2>&1 | solfmt`;
+      await $`RUST_LOG=error cargo test-sbf ${process.argv.slice(3)} 2>&1 | solfmt`;
     } else {
-      await $`RUST_LOG=error cargo test-sbf ${argv._}`;
+      await $`RUST_LOG=error cargo test-sbf ${process.argv.slice(3)}`;
     }
   })
 );

--- a/template/base/scripts/program/test.mjs
+++ b/template/base/scripts/program/test.mjs
@@ -8,7 +8,7 @@ import './dump.mjs';
 // Test the programs.
 await Promise.all(
   getProgramFolders().map(async (folder) => {
-    await $`cd ${path.join(workingDirectory, folder)}`.quiet();
+    cd(`${path.join(workingDirectory, folder)}`);
     const hasSolfmt = await which('solfmt', { nothrow: true });
 
     if (hasSolfmt) {

--- a/template/clients/js/scripts/client/test-js.mjs
+++ b/template/clients/js/scripts/client/test-js.mjs
@@ -9,4 +9,4 @@ await $`pnpm validator:restart`;
 cd(path.join(workingDirectory, 'clients', 'js'));
 await $`pnpm install`;
 await $`pnpm build`;
-await $`pnpm test ${argv._}`;
+await $`pnpm test ${process.argv.slice(3)}`;

--- a/template/clients/rust/scripts/client/lint-rust.mjs
+++ b/template/clients/rust/scripts/client/lint-rust.mjs
@@ -4,4 +4,4 @@ import { workingDirectory } from '../utils.mjs';
 
 // Check the client using Clippy.
 cd(path.join(workingDirectory, 'clients', 'rust'));
-await $`cargo clippy ${argv._}`;
+await $`cargo clippy ${process.argv.slice(3)}`;

--- a/template/clients/rust/scripts/client/test-rust.mjs
+++ b/template/clients/rust/scripts/client/test-rust.mjs
@@ -6,7 +6,7 @@ import { workingDirectory } from '../utils.mjs';
 cd(path.join(workingDirectory, 'clients', 'rust'));
 const hasSolfmt = await which('solfmt', { nothrow: true });
 if (hasSolfmt) {
-  await $`cargo test-sbf ${argv._} 2>&1 | solfmt`;
+  await $`cargo test-sbf ${process.argv.slice(3)} 2>&1 | solfmt`;
 } else {
-  await $`cargo test-sbf ${argv._}`;
+  await $`cargo test-sbf ${process.argv.slice(3)}`;
 }


### PR DESCRIPTION
This PR updates the script to use the `cd` function to change directory instead of `await $cd <folder>.quiet()`. The latter changes the directory in a sub-process, so the change is not "persisted" on the caller.

Relevant commit (since this is a stacked PR):
* [Switch to use cd function](https://github.com/solana-program/create-solana-program/pull/57/commits/e42738c74b86e2642ffc278ca494d66dc57c041c)