### PR TITLE
Use loop to build programs programs

### DIFF
--- a/.changeset/hungry-forks-worry.md
+++ b/.changeset/hungry-forks-worry.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Switch to use cd function

--- a/.changeset/many-llamas-add.md
+++ b/.changeset/many-llamas-add.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Use loop to build programs sequentially

--- a/.changeset/nasty-timers-lay.md
+++ b/.changeset/nasty-timers-lay.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Fix command-line args parsing on scripts

--- a/template/base/scripts/program/build.mjs
+++ b/template/base/scripts/program/build.mjs
@@ -9,6 +9,6 @@ import './dump.mjs';
 await Promise.all(
   getProgramFolders().map(async (folder) => {
     await $`cd ${path.join(workingDirectory, folder)}`.quiet();
-    await $`cargo-build-sbf ${argv._}`;
+    await $`cargo-build-sbf ${process.argv.slice(3)}`;
   })
 );

--- a/template/base/scripts/program/build.mjs
+++ b/template/base/scripts/program/build.mjs
@@ -6,9 +6,7 @@ import { workingDirectory, getProgramFolders } from '../utils.mjs';
 import './dump.mjs';
 
 // Build the programs.
-await Promise.all(
-  getProgramFolders().map(async (folder) => {
-    cd(`${path.join(workingDirectory, folder)}`);
-    await $`cargo-build-sbf ${process.argv.slice(3)}`;
-  })
-);
+for (const folder of getProgramFolders()) {
+  cd(`${path.join(workingDirectory, folder)}`);
+  await $`cargo-build-sbf ${process.argv.slice(3)}`;
+}

--- a/template/base/scripts/program/build.mjs
+++ b/template/base/scripts/program/build.mjs
@@ -8,7 +8,7 @@ import './dump.mjs';
 // Build the programs.
 await Promise.all(
   getProgramFolders().map(async (folder) => {
-    await $`cd ${path.join(workingDirectory, folder)}`.quiet();
+    cd(`${path.join(workingDirectory, folder)}`);
     await $`cargo-build-sbf ${process.argv.slice(3)}`;
   })
 );

--- a/template/base/scripts/program/format.mjs
+++ b/template/base/scripts/program/format.mjs
@@ -5,7 +5,7 @@ import { workingDirectory, getProgramFolders } from '../utils.mjs';
 // Format the programs.
 await Promise.all(
   getProgramFolders().map(async (folder) => {
-    await $`cd ${path.join(workingDirectory, folder)}`.quiet();
+    cd(`${path.join(workingDirectory, folder)}`);
     await $`cargo fmt ${process.argv.slice(3)}`;
   })
 );

--- a/template/base/scripts/program/format.mjs
+++ b/template/base/scripts/program/format.mjs
@@ -6,6 +6,6 @@ import { workingDirectory, getProgramFolders } from '../utils.mjs';
 await Promise.all(
   getProgramFolders().map(async (folder) => {
     await $`cd ${path.join(workingDirectory, folder)}`.quiet();
-    await $`cargo fmt ${argv._}`;
+    await $`cargo fmt ${process.argv.slice(3)}`;
   })
 );

--- a/template/base/scripts/program/format.mjs
+++ b/template/base/scripts/program/format.mjs
@@ -3,9 +3,7 @@ import 'zx/globals';
 import { workingDirectory, getProgramFolders } from '../utils.mjs';
 
 // Format the programs.
-await Promise.all(
-  getProgramFolders().map(async (folder) => {
-    cd(`${path.join(workingDirectory, folder)}`);
-    await $`cargo fmt ${process.argv.slice(3)}`;
-  })
-);
+for (const folder of getProgramFolders()) {
+  cd(`${path.join(workingDirectory, folder)}`);
+  await $`cargo fmt ${process.argv.slice(3)}`;
+}

--- a/template/base/scripts/program/lint.mjs
+++ b/template/base/scripts/program/lint.mjs
@@ -3,9 +3,7 @@ import 'zx/globals';
 import { workingDirectory, getProgramFolders } from '../utils.mjs';
 
 // Lint the programs using clippy.
-await Promise.all(
-  getProgramFolders().map(async (folder) => {
-    cd(`${path.join(workingDirectory, folder)}`);
-    await $`cargo clippy ${process.argv.slice(3)}`;
-  })
-);
+for (const folder of getProgramFolders()) {
+  cd(`${path.join(workingDirectory, folder)}`);
+  await $`cargo clippy ${process.argv.slice(3)}`;
+}

--- a/template/base/scripts/program/lint.mjs
+++ b/template/base/scripts/program/lint.mjs
@@ -6,6 +6,6 @@ import { workingDirectory, getProgramFolders } from '../utils.mjs';
 await Promise.all(
   getProgramFolders().map(async (folder) => {
     await $`cd ${path.join(workingDirectory, folder)}`.quiet();
-    await $`cargo clippy ${argv._}`;
+    await $`cargo clippy ${process.argv.slice(3)}`;
   })
 );

--- a/template/base/scripts/program/lint.mjs
+++ b/template/base/scripts/program/lint.mjs
@@ -5,7 +5,7 @@ import { workingDirectory, getProgramFolders } from '../utils.mjs';
 // Lint the programs using clippy.
 await Promise.all(
   getProgramFolders().map(async (folder) => {
-    await $`cd ${path.join(workingDirectory, folder)}`.quiet();
+    cd(`${path.join(workingDirectory, folder)}`);
     await $`cargo clippy ${process.argv.slice(3)}`;
   })
 );

--- a/template/base/scripts/program/test.mjs
+++ b/template/base/scripts/program/test.mjs
@@ -12,9 +12,9 @@ await Promise.all(
     const hasSolfmt = await which('solfmt', { nothrow: true });
 
     if (hasSolfmt) {
-      await $`RUST_LOG=error cargo test-sbf ${argv._} 2>&1 | solfmt`;
+      await $`RUST_LOG=error cargo test-sbf ${process.argv.slice(3)} 2>&1 | solfmt`;
     } else {
-      await $`RUST_LOG=error cargo test-sbf ${argv._}`;
+      await $`RUST_LOG=error cargo test-sbf ${process.argv.slice(3)}`;
     }
   })
 );

--- a/template/base/scripts/program/test.mjs
+++ b/template/base/scripts/program/test.mjs
@@ -5,16 +5,14 @@ import { workingDirectory, getProgramFolders } from '../utils.mjs';
 // Save external programs binaries to the output directory.
 import './dump.mjs';
 
+const hasSolfmt = await which('solfmt', { nothrow: true });
 // Test the programs.
-await Promise.all(
-  getProgramFolders().map(async (folder) => {
-    cd(`${path.join(workingDirectory, folder)}`);
-    const hasSolfmt = await which('solfmt', { nothrow: true });
+for (const folder of getProgramFolders()) {
+  cd(`${path.join(workingDirectory, folder)}`);
 
-    if (hasSolfmt) {
-      await $`RUST_LOG=error cargo test-sbf ${process.argv.slice(3)} 2>&1 | solfmt`;
-    } else {
-      await $`RUST_LOG=error cargo test-sbf ${process.argv.slice(3)}`;
-    }
-  })
-);
+  if (hasSolfmt) {
+    await $`RUST_LOG=error cargo test-sbf ${process.argv.slice(3)} 2>&1 | solfmt`;
+  } else {
+    await $`RUST_LOG=error cargo test-sbf ${process.argv.slice(3)}`;
+  }
+}

--- a/template/base/scripts/program/test.mjs
+++ b/template/base/scripts/program/test.mjs
@@ -8,7 +8,7 @@ import './dump.mjs';
 // Test the programs.
 await Promise.all(
   getProgramFolders().map(async (folder) => {
-    await $`cd ${path.join(workingDirectory, folder)}`.quiet();
+    cd(`${path.join(workingDirectory, folder)}`);
     const hasSolfmt = await which('solfmt', { nothrow: true });
 
     if (hasSolfmt) {

--- a/template/clients/js/scripts/client/test-js.mjs
+++ b/template/clients/js/scripts/client/test-js.mjs
@@ -9,4 +9,4 @@ await $`pnpm validator:restart`;
 cd(path.join(workingDirectory, 'clients', 'js'));
 await $`pnpm install`;
 await $`pnpm build`;
-await $`pnpm test ${argv._}`;
+await $`pnpm test ${process.argv.slice(3)}`;

--- a/template/clients/rust/scripts/client/lint-rust.mjs
+++ b/template/clients/rust/scripts/client/lint-rust.mjs
@@ -4,4 +4,4 @@ import { workingDirectory } from '../utils.mjs';
 
 // Check the client using Clippy.
 cd(path.join(workingDirectory, 'clients', 'rust'));
-await $`cargo clippy ${argv._}`;
+await $`cargo clippy ${process.argv.slice(3)}`;

--- a/template/clients/rust/scripts/client/test-rust.mjs
+++ b/template/clients/rust/scripts/client/test-rust.mjs
@@ -6,7 +6,7 @@ import { workingDirectory } from '../utils.mjs';
 cd(path.join(workingDirectory, 'clients', 'rust'));
 const hasSolfmt = await which('solfmt', { nothrow: true });
 if (hasSolfmt) {
-  await $`cargo test-sbf ${argv._} 2>&1 | solfmt`;
+  await $`cargo test-sbf ${process.argv.slice(3)} 2>&1 | solfmt`;
 } else {
-  await $`cargo test-sbf ${argv._}`;
+  await $`cargo test-sbf ${process.argv.slice(3)}`;
 }


### PR DESCRIPTION
This PR update the scripts to use a loop when building programs to avoid cargo locking warnings. Currently, scripts build programs in parallel, but this is unnecessary:
1. It creates a write-contention on the `Cargo.lock` file since this is a workspace-wide file.
2. `cargo build` already uses all cores available by default, so there is no real speed up in building programs in parallel.

This is a stacked PR, the relevant commit is:
* [Use loop over programs](https://github.com/solana-program/create-solana-program/commit/9daf8c76c689f8281ff1215ad81be33a6f51cb21)