### PR TITLE
Install Solana in CI for Anchor IDL checks

### DIFF
--- a/.changeset/strange-news-pretend.md
+++ b/.changeset/strange-news-pretend.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Install Solana in CI for Anchor IDL checks

--- a/template/base/.github/workflows/main.yml.njk
+++ b/template/base/.github/workflows/main.yml.njk
@@ -147,6 +147,7 @@ jobs:
           cargo-cache-local-key: cargo-local
           node: {% raw %}${{ env.NODE_VERSION }}{% endraw %}
 {% if programFramework === 'anchor' %}
+          solana: {% raw %}${{ env.SOLANA_VERSION }}{% endraw %}
           anchor: {% raw %}${{ env.ANCHOR_VERSION }}{% endraw %}
 {% endif %}
 


### PR DESCRIPTION
This PR fixes the CI of the Anchor generated snapshot by installing Solana in the Check IDL job — needed for Anchor only.

See https://github.com/lorisleiva/counter-anchor-ci-tests/pull/1.