### PR TITLE
Add description and repository to Rust client Cargo.toml

### DIFF
--- a/.changeset/kind-flowers-breathe.md
+++ b/.changeset/kind-flowers-breathe.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Add description and repository to Rust client Cargo.toml

--- a/template/clients/rust/clients/rust/Cargo.toml.njk
+++ b/template/clients/rust/clients/rust/Cargo.toml.njk
@@ -1,6 +1,8 @@
 [package]
 name = "{{ rustClientCrateName }}"
 version = "0.0.0"
+description = "A generated Rust library for the {{ programName | titleCase }} program"
+repository = "https://github.com/{{ organizationName }}/{{ targetDirectoryName }}"
 edition = "2021"
 readme = "README.md"
 license-file = "../../LICENSE"


### PR DESCRIPTION
This PR adds the `description` and `repository` attributes to the Rust client's `Cargo.toml` file. This allows the Rust crate to be released to crates.io.