### PR TITLE
Improve Solana version link script

### DIFF
--- a/.changeset/plenty-tools-invite.md
+++ b/.changeset/plenty-tools-invite.md
@@ -1,0 +1,7 @@
+---
+"create-solana-program": patch
+---
+
+Improve Solana version link script
+
+`pnpm solana:link` now also asks you to download the required Solana version if it's not already installed. Additionally, if the required Solana version is equal to or greater than `1.18.19`, the install URL will use `release.anza.xyz` instead of `release.solana.com`.

--- a/template/base/scripts/check-solana-version.mjs
+++ b/template/base/scripts/check-solana-version.mjs
@@ -5,7 +5,13 @@ import { getInstalledSolanaVersion, getSolanaVersion } from './utils.mjs';
 const expectedVersion = getSolanaVersion();
 const installedVersion = await getInstalledSolanaVersion();
 
-if (installedVersion !== expectedVersion) {
+if (!installedVersion) {
+  echo(
+    chalk.red('[ ERROR ]'),
+    `No Solana installation found. Please install Solana ${expectedVersion} before proceeding.`
+  );
+  process.exit(1);
+} else if (installedVersion !== expectedVersion) {
   echo(
     chalk.yellow('[ WARNING ]'),
     `The installed Solana version ${installedVersion} does not match the expected version ${expectedVersion}.`

--- a/template/base/scripts/utils.mjs
+++ b/template/base/scripts/utils.mjs
@@ -121,10 +121,6 @@ export async function getInstalledSolanaVersion() {
     const { stdout } = await $`solana --version`.quiet();
     return stdout.match(/(\d+\.\d+\.\d+)/)?.[1];
   } catch (error) {
-    echo(
-      chalk.red('[ ERROR ]'),
-      `No Solana installation found. Please install Solana ${getSolanaVersion()} before proceeding.`
-    );
-    process.exit(1);
+    return '';
   }
 }


### PR DESCRIPTION
This PR updates the `pnpm solana:link` script such that:
- it also asks you to download the required Solana version if Solana is not installed at all.
- if the required Solana version is equal to or greater than `1.18.19`, the install URL will use `release.anza.xyz` instead of `release.solana.com`.