### PR TITLE
Use `lint` toolchain in program lint script

### DIFF
--- a/template/base/scripts/program/lint.mjs
+++ b/template/base/scripts/program/lint.mjs
@@ -13,7 +13,7 @@ import {
 const lintArgs = cliArguments();
 
 const fix = popArgument(lintArgs, '--fix');
-const toolchain = getToolchainArgument('format');
+const toolchain = getToolchainArgument('lint');
 
 // Lint the programs using clippy.
 await Promise.all(


### PR DESCRIPTION
#### Problem
The program lint script at `scripts/program/lint.mjs` is using the toolchain for `format` instead of `lint`.

#### Summary of Changes
Update it to use `lint`!