### PR TITLE
Use loop on program scripts

### DIFF
--- a/.changeset/mean-ducks-lick.md
+++ b/.changeset/mean-ducks-lick.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Use loop on program scripts

--- a/template/base/scripts/program/build.mjs
+++ b/template/base/scripts/program/build.mjs
@@ -14,10 +14,8 @@ import './dump.mjs';
 const buildArgs = cliArguments();
 
 // Build the programs.
-await Promise.all(
-  getProgramFolders().map(async (folder) => {
-    const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
+for (const folder of getProgramFolders()) {
+  const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
 
-    await $`cargo-build-sbf --manifest-path ${manifestPath} ${buildArgs}`;
-  })
-);
+  await $`cargo-build-sbf --manifest-path ${manifestPath} ${buildArgs}`;
+}

--- a/template/base/scripts/program/format.mjs
+++ b/template/base/scripts/program/format.mjs
@@ -18,14 +18,12 @@ const [cargoArgs, fmtArgs] = partitionArguments(formatArgs, '--');
 const toolchain = getToolchainArgument('format');
 
 // Format the programs.
-await Promise.all(
-  getProgramFolders().map(async (folder) => {
-    const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
+for (const folder of getProgramFolders()) {
+  const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
 
-    if (fix) {
-      await $`cargo ${toolchain} fmt --manifest-path ${manifestPath} ${cargoArgs} -- ${fmtArgs}`;
-    } else {
-      await $`cargo ${toolchain} fmt --manifest-path ${manifestPath} ${cargoArgs} -- --check ${fmtArgs}`;
-    }
-  })
-);
+  if (fix) {
+    await $`cargo ${toolchain} fmt --manifest-path ${manifestPath} ${cargoArgs} -- ${fmtArgs}`;
+  } else {
+    await $`cargo ${toolchain} fmt --manifest-path ${manifestPath} ${cargoArgs} -- --check ${fmtArgs}`;
+  }
+}

--- a/template/base/scripts/program/lint.mjs
+++ b/template/base/scripts/program/lint.mjs
@@ -16,14 +16,12 @@ const fix = popArgument(lintArgs, '--fix');
 const toolchain = getToolchainArgument('lint');
 
 // Lint the programs using clippy.
-await Promise.all(
-  getProgramFolders().map(async (folder) => {
-    const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
+for (const folder of getProgramFolders()) {
+  const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
 
-    if (fix) {
-      await $`cargo ${toolchain} clippy --manifest-path ${manifestPath} --fix ${lintArgs}`;
-    } else {
-      await $`cargo ${toolchain} clippy --manifest-path ${manifestPath} ${lintArgs}`;
-    }
-  })
-);
+  if (fix) {
+    await $`cargo ${toolchain} clippy --manifest-path ${manifestPath} --fix ${lintArgs}`;
+  } else {
+    await $`cargo ${toolchain} clippy --manifest-path ${manifestPath} ${lintArgs}`;
+  }
+}

--- a/template/base/scripts/program/test.mjs
+++ b/template/base/scripts/program/test.mjs
@@ -16,14 +16,12 @@ const testArgs = cliArguments();
 const hasSolfmt = await which('solfmt', { nothrow: true });
 
 // Test the programs.
-await Promise.all(
-  getProgramFolders().map(async (folder) => {
-    const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
+for (const folder of getProgramFolders()) {
+  const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
 
-    if (hasSolfmt) {
-      await $`RUST_LOG=error cargo test-sbf --manifest-path ${manifestPath} ${testArgs} 2>&1 | solfmt`;
-    } else {
-      await $`RUST_LOG=error cargo test-sbf --manifest-path ${manifestPath} ${testArgs}`;
-    }
-  })
-);
+  if (hasSolfmt) {
+    await $`RUST_LOG=error cargo test-sbf --manifest-path ${manifestPath} ${testArgs} 2>&1 | solfmt`;
+  } else {
+    await $`RUST_LOG=error cargo test-sbf --manifest-path ${manifestPath} ${testArgs}`;
+  }
+}


### PR DESCRIPTION
### Problem

Currently, program scripts use a `Promise` to build all programs concurrently in the project. This is not ideal for projects with multiple programs since `cargo` tries to concurrently get file locks:

<img src="https://github.com/user-attachments/assets/1f936f88-40be-444e-88c1-efbd78305d6a" width="400" />

### Solution

Replace the use of `Promise` for a loop, so programs are built sequentially. This does not have an impact on build speed since `cargo` performs the build using all available processors/cores.