### PR TITLE
Use cargo test directly

### DIFF
--- a/.changeset/wet-lions-taste.md
+++ b/.changeset/wet-lions-taste.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Use cargo test directly on Rust client script

--- a/template/clients/rust/scripts/client/test-rust.mjs
+++ b/template/clients/rust/scripts/client/test-rust.mjs
@@ -7,11 +7,12 @@ import { cliArguments, workingDirectory } from '../utils.mjs';
 const testArgs = cliArguments();
 
 const hasSolfmt = await which('solfmt', { nothrow: true });
+const sbfOutDir = path.join(workingDirectory, 'target', 'deploy');
 
 // Run the tests.
 cd(path.join(workingDirectory, 'clients', 'rust'));
 if (hasSolfmt) {
-  await $`cargo test-sbf ${testArgs} 2>&1 | solfmt`;
+  await $`SBF_OUT_DIR=${sbfOutDir} cargo test ${testArgs} 2>&1 | solfmt`;
 } else {
-  await $`cargo test-sbf ${testArgs}`;
+  await $`SBF_OUT_DIR=${sbfOutDir} cargo test ${testArgs}`;
 }

--- a/template/clients/rust/scripts/client/test-rust.mjs
+++ b/template/clients/rust/scripts/client/test-rust.mjs
@@ -12,7 +12,7 @@ const sbfOutDir = path.join(workingDirectory, 'target', 'deploy');
 // Run the tests.
 cd(path.join(workingDirectory, 'clients', 'rust'));
 if (hasSolfmt) {
-  await $`SBF_OUT_DIR=${sbfOutDir} cargo test ${testArgs} 2>&1 | solfmt`;
+  await $`SBF_OUT_DIR=${sbfOutDir} cargo test --features "test-sbf" ${testArgs} 2>&1 | solfmt`;
 } else {
-  await $`SBF_OUT_DIR=${sbfOutDir} cargo test ${testArgs}`;
+  await $`SBF_OUT_DIR=${sbfOutDir} cargo test --features "test-sbf" ${testArgs}`;
 }


### PR DESCRIPTION
### Problem

Currently, the `test-rust.msj` script uses `cargo test-sbf` to run the client tests. This unnecessarily compiles the code twice.

### Solution

This PR updates the script to use `cargo test` directly, setting the correct `SBF_OUT_DIR` variable to avoid the need to use `cargo test-sbf`.