### PR TITLE
Use `install-solana` action from solana program

### DIFF
--- a/.changeset/afraid-queens-grow.md
+++ b/.changeset/afraid-queens-grow.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Use install-solana action from solana-program

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Solana
-        uses: metaplex-foundation/actions/install-solana@v1
+        uses: solana-program/actions/install-solana@v1
         with:
           version: ${{ matrix.solana }}
       - name: Install Rustfmt
@@ -119,7 +119,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Solana
-        uses: metaplex-foundation/actions/install-solana@v1
+        uses: solana-program/actions/install-solana@v1
         with:
           version: ${{ env.SOLANA_VERSION }}
       - name: Install Anchor

--- a/template/base/.github/actions/setup/action.yml.njk
+++ b/template/base/.github/actions/setup/action.yml.njk
@@ -70,7 +70,7 @@ runs:
 
     - name: Install Solana
       if: {% raw %}${{ inputs.solana == 'true' }}{% endraw %}
-      uses: metaplex-foundation/actions/install-solana@v1
+      uses: solana-program/actions/install-solana@v1
       with:
         version: {% raw %}${{ env.SOLANA_VERSION }}{% endraw %}
         cache: true


### PR DESCRIPTION
This PR updates the template to use the `install-solana` action from the solana-program repository to support using symbolic channels as version tag.