### PR TITLE
Use `2.0.0-rc.4` version of web3.js

### DIFF
--- a/.changeset/swift-bottles-promise.md
+++ b/.changeset/swift-bottles-promise.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Use `2.0.0-rc.2` version of web3.js

--- a/.changeset/swift-bottles-promise.md
+++ b/.changeset/swift-bottles-promise.md
@@ -2,4 +2,4 @@
 "create-solana-program": patch
 ---
 
-Use `2.0.0-rc.3` version of web3.js
+Use `2.0.0-rc.4` version of web3.js

--- a/.changeset/swift-bottles-promise.md
+++ b/.changeset/swift-bottles-promise.md
@@ -2,4 +2,4 @@
 "create-solana-program": patch
 ---
 
-Use `2.0.0-rc.2` version of web3.js
+Use `2.0.0-rc.3` version of web3.js

--- a/template/clients/js/clients/js/package.json.njk
+++ b/template/clients/js/clients/js/package.json.njk
@@ -42,12 +42,12 @@
   "homepage": "{{ repositoryUrl }}#readme",
   "license": "MIT",
   "peerDependencies": {
-    "@solana/web3.js": "2.0.0-canary-20241105102652"
+    "@solana/web3.js": "2.0.0-rc.4"
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.3",
-    "@solana/web3.js": "2.0.0-canary-20241105102652",
+    "@solana/web3.js": "2.0.0-rc.4",
     "@types/node": "^20",
     "@typescript-eslint/eslint-plugin": "^7.16.1",
     "@typescript-eslint/parser": "^7.16.1",

--- a/template/clients/js/clients/js/package.json.njk
+++ b/template/clients/js/clients/js/package.json.njk
@@ -42,12 +42,12 @@
   "homepage": "{{ repositoryUrl }}#readme",
   "license": "MIT",
   "peerDependencies": {
-    "@solana/web3.js": "2.0.0-rc.3"
+    "@solana/web3.js": "2.0.0-canary-20241105102652"
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.3",
-    "@solana/web3.js": "2.0.0-rc.3",
+    "@solana/web3.js": "2.0.0-canary-20241105102652",
     "@types/node": "^20",
     "@typescript-eslint/eslint-plugin": "^7.16.1",
     "@typescript-eslint/parser": "^7.16.1",

--- a/template/clients/js/clients/js/package.json.njk
+++ b/template/clients/js/clients/js/package.json.njk
@@ -42,12 +42,12 @@
   "homepage": "{{ repositoryUrl }}#readme",
   "license": "MIT",
   "peerDependencies": {
-    "@solana/web3.js": "2.0.0-rc.2"
+    "@solana/web3.js": "2.0.0-rc.3"
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.3",
-    "@solana/web3.js": "2.0.0-rc.2",
+    "@solana/web3.js": "2.0.0-rc.3",
     "@types/node": "^20",
     "@typescript-eslint/eslint-plugin": "^7.16.1",
     "@typescript-eslint/parser": "^7.16.1",

--- a/template/clients/js/clients/js/package.json.njk
+++ b/template/clients/js/clients/js/package.json.njk
@@ -42,12 +42,12 @@
   "homepage": "{{ repositoryUrl }}#readme",
   "license": "MIT",
   "peerDependencies": {
-    "@solana/web3.js": "2.0.0-rc.1"
+    "@solana/web3.js": "2.0.0-rc.2"
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.3",
-    "@solana/web3.js": "2.0.0-rc.1",
+    "@solana/web3.js": "2.0.0-rc.2",
     "@types/node": "^20",
     "@typescript-eslint/eslint-plugin": "^7.16.1",
     "@typescript-eslint/parser": "^7.16.1",


### PR DESCRIPTION
This PR bumps the version of web3.js to the latest available release candidate.