### PR TITLE
Create `workspace.members` config for Anchor 0.30

### DIFF
--- a/.changeset/chilly-hotels-report.md
+++ b/.changeset/chilly-hotels-report.md
@@ -1,0 +1,5 @@
+---
+"create-solana-program": patch
+---
+
+Added a `workspace.members` config for Anchor 0.30 compatibility

--- a/template/anchor/base/Anchor.toml.njk
+++ b/template/anchor/base/Anchor.toml.njk
@@ -1,3 +1,8 @@
+[workspace]
+members = [
+    "program",
+]
+
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"


### PR DESCRIPTION
This is new, apparently. Anchor 0.30 commands won't find a program to operate on without this.

https://www.anchor-lang.com/docs/references/anchor-toml#members

# Test Plan

`anchor keys list` does something whereas it did not before.