### PR TITLE
feat(template): pass in cli args to shank-js when generating idl

### DIFF
--- a/template/base/scripts/generate-idls.mjs
+++ b/template/base/scripts/generate-idls.mjs
@@ -9,6 +9,7 @@ getProgramFolders().forEach((folder) => {
   const cargo = getCargo(folder);
   const isShank = Object.keys(cargo.dependencies).includes('shank');
   const programDir = path.join(__dirname, '..', folder);
+  const extraArgs = process.argv.slice(3);
 
   generateIdl({
     generator: isShank ? 'shank' : 'anchor',
@@ -18,5 +19,6 @@ getProgramFolders().forEach((folder) => {
     idlName: 'idl',
     programDir,
     binaryInstallDir,
+    binaryExtraArgs: extraArgs,
   });
 });


### PR DESCRIPTION
allowing passing in CLI when you want to generate IDL for different environments e.g dev vs prod